### PR TITLE
fix: sbomReport specVersion is string

### DIFF
--- a/deploy/helm/crds/aquasecurity.github.io_sbomreports.yaml
+++ b/deploy/helm/crds/aquasecurity.github.io_sbomreports.yaml
@@ -261,7 +261,7 @@ spec:
                   serialNumber:
                     type: string
                   specVersion:
-                    type: integer
+                    type: string
                   version:
                     type: integer
                 required:

--- a/deploy/static/trivy-operator.yaml
+++ b/deploy/static/trivy-operator.yaml
@@ -1761,7 +1761,7 @@ spec:
                   serialNumber:
                     type: string
                   specVersion:
-                    type: integer
+                    type: string
                   version:
                     type: integer
                 required:

--- a/docs/docs/crds/sbom-report.md
+++ b/docs/docs/crds/sbom-report.md
@@ -155,7 +155,7 @@ report:
       - name: trivy
         vendor: aquasecurity
     serialNumber: urn:uuid:50dbce86-28c5-4caf-9d08-a4aadf23233e
-    specVersion: 5
+    specVersion: 1.4
     version: 1
   registry:
     server: k8s.gcr.io

--- a/pkg/apis/aquasecurity/v1alpha1/sbom_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/sbom_types.go
@@ -60,7 +60,7 @@ type SbomReportData struct {
 
 type BOM struct {
 	BOMFormat   string `json:"bomFormat"`
-	SpecVersion int    `json:"specVersion"`
+	SpecVersion string `json:"specVersion"`
 
 	SerialNumber string        `json:"serialNumber,omitempty"`
 	Version      int           `json:"version,omitempty"`

--- a/pkg/plugins/trivy/util.go
+++ b/pkg/plugins/trivy/util.go
@@ -12,7 +12,7 @@ func cycloneDxBomToReport(cbom cdx.BOM) *v1alpha1.BOM {
 	}
 	return &v1alpha1.BOM{
 		BOMFormat:    cbom.BOMFormat,
-		SpecVersion:  int(cbom.SpecVersion),
+		SpecVersion:  cbom.SpecVersion.String(),
 		SerialNumber: cbom.SerialNumber,
 		Version:      cbom.Version,
 		Metadata:     cycloneDxMetadataToReportMetadata(cbom.Metadata),


### PR DESCRIPTION
## Description

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy-operator/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy-operator/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
